### PR TITLE
fix issue 42

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: boolean
         default: false
+      pages:
+        description: 'Deploy HTML to Github pages?'
+        required: false
+        type: boolean
+        default: false
   pull_request:
   push:
     branches:
@@ -33,40 +38,51 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # Step 1: Checkout the repository
+    # Checkout the repository
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
-    # Step 2: Pull the latest RISC-V Docs container image
+    # Pull the latest RISC-V Docs container image
     - name: Pull Container
       run: docker pull riscvintl/riscv-docs-base-container-image:latest
 
-    # Step 3: Build Files
+    # Build PDF and HTML.
     - name: Build Files
       run: make all
       env:
         VERSION: v${{ github.event.inputs.version }}
         REVMARK: ${{ github.event.inputs.revision_mark }}
 
-    # Step 4: Upload the built PDF and HTML files as a single artifact
+    # Upload the built PDF and HTML files as a single artifact
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v3
       with:
         name: Build Artifacts
         path: |
-          ${{ github.workspace }}/build/*.pdf
-          ${{ github.workspace }}/build/*.html
+          build/*.pdf
+          build/*.html
         retention-days: 30
+
+    # Upload gitlab pages artefact.
+    - name: Make gitlab pages directory
+      run: mkdir dist && cp build/*.html dist/index.html
+      if: github.event_name == 'workflow_dispatch'
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: dist
+      if: github.event_name == 'workflow_dispatch'
 
     # Create Release
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          ${{ github.workspace }}/build/*.pdf
-          ${{ github.workspace }}/build/*.html
+          build/*.pdf
+          build/*.html
         tag_name: v${{ github.event.inputs.version }}
         name: Release ${{ github.event.inputs.version }}
         draft: ${{ github.event.inputs.draft }}
@@ -75,3 +91,23 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
       if: github.event_name == 'workflow_dispatch'
       # This condition ensures this step only runs for workflow_dispatch events.
+
+  # Deploy HTML to Github pages.
+  deploy:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.pages
+
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -459,10 +459,11 @@ or 'root' capability.
 | B       | zeros | Base address bits
 | B~E~    | zeros | Exponent bits
 | Address | zeros | Capability address
+| Reserved| zeros | All reserved fields
 |==============================================================================
 
 .Field values of the Infinite capability
-[#infinite-cap,reftext="Infinity"]
+[#infinite-cap,reftext="Infinite"]
 [options=header,width="100%",align=center,width="55%",cols="1,1,3"]
 |==============================================================================
 | Field   | Value | Comment
@@ -476,6 +477,7 @@ or 'root' capability.
 | B       | zeros | Base address bits
 | B~E~    | zeros | Exponent bits
 | Address | zeros | Capability address
+| Reserved| zeros | All reserved fields
 |==============================================================================
 
 [#section_cap_representable_check]
@@ -520,4 +522,3 @@ bits!
 
 Capabilities with malformed bounds are always invalid anywhere in the system
 i.e. their tags are always 0.
-

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -509,7 +509,7 @@ bounds are formed of two or three sections:
 [#comp_addr_bounds,options=header,align="center"]
 |==============================================================================
 | Configuration  | Upper section | Middle Section | Lower section
-| EF=0, E varies | address[XLENMAX-1:E + MW] + ct | T[MW - 1:0] | {E{1'b0}}
+| EF=0, i.e. E>0 | address[XLENMAX-1:E + MW] + ct | T[MW - 1:0] | {E{1'b0}}
 | EF=1, i.e. E=0 | address[XLENMAX:MW] + ct     2+| T[MW - 1:0]
 |==============================================================================
 

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -349,13 +349,6 @@ Decoding the bounds:
 top:    t = { a[XLENMAX - 1:E + MW] + ct, T[MW - 1:0]    , {E{1'b0}} }
 base:   b = { a[XLENMAX - 1:E + MW] + cb, B[MW - 1:0]    , {E{1'b0}} }
 ```
-NOTE: The representable range
- is defined by the space beneath the bottom address bit (`a[E + MW]`)
- in the expression above. If the capability address changes causing that address bit
- to change, then the representable range is violated and so the tag will be cleared
- by an instruction such as <<CINCOFFSET>>. This is represented by a range
- of `s=2^E+MW^` in xref:cap_bounds_map[xrefstyle=short].
-
 The corrections c~t~ and c~b~ are calculated as as shown below using the
 definitions in xref:cap_encoding_ct[xrefstyle=short] and
 xref:cap_encoding_cb[xrefstyle=short].
@@ -423,7 +416,7 @@ A capability whose bounds cover the entire address space has 0 base and top
 equals 2^XLENMAX^, i.e. _t_ is a XLENMAX + 1 bit value. However, _b_ is a
 XLENMAX bit value and the size mismatch introduces additional complications
 when decoding, so the following condition is required to correct _t_ for
-capabilities whose representable region wraps the edge of the address
+capabilities whose <<section_cap_representable_check>> wraps the edge of the address
 space:
 
 ```
@@ -484,28 +477,60 @@ or 'root' capability.
 | Address | zeros | Capability address
 |==============================================================================
 
-[#section_cap_representable_check]
-=== Representable Limit Check
+[#section_cap_representable_check, reftext="Representable Range"]
+=== Representable Range Check
 
-Pointer arithmetic on capabilities must be checked to ensure that the new
-address is within the capability's representable region described in
-xref:section_cap_encoding[xrefstyle=short]. The new address, after pointer
-arithmetic, is within the representable region if decompressing the
-capability's bounds with the original and new addresses yields the same base
-and top addresses. In other words, given a capability with address _a_ and the
+The new address, after updating the address of a capability, is within the
+_representable range_ if decompressing the capability's bounds with the
+original and new addresses yields the same base and top addresses.
+
+In other words, given a capability with address _a_ and the
 new address `a' = a + x`, the bounds _b_ and _t_ are decoded using _a_ and the
 new bounds _b'_ and _t'_ are decoded using _a'_. The new address is within the
-capability's representable region if `b == b' && t == t'`.
+capability's _representable range_ if `b == b' && t == t'`.
 
-Changing a capability's address to a value outside the representable region
-unconditionally clears the capability's tag.
+Changing a capability's address to a value outside the _representable range_
+unconditionally clears the capability's tag. Examples are:
 
-NOTE: The encoding of the bounds depends upon the leading 1 of the address
-which is used to determine the exponent. If the leading 1 of the address moves
-then the bounds will need to be recalculated. Instructions like <<CINCOFFSET>>
-and <<CSETADDR>> update the address field but do not recalculate the bounds.
-Therefore, if the leading 1 moves relative to when the bounds were calculated
-then the tag is cleared on the result as the encoding has been invalidated.
+* Instructions such as <<CINCOFFSET>> which include pointer arithmetic.
+* The <<CSETADDR>> instruction which updates the capability address field.
+
+==== Practical Information
+
+In the bounds encoding in this specification, the top and bottom capability
+bounds are formed of two or three sections:
+
+* Upper bits from the address
+* Middle bits from T and B decoded from the metadata
+* Lower bits are set to zero
+** This is only if there is an embedded exponent (EF=0)
+
+.Composition of address bounds
+[#comp_addr_bounds,options=header,align="center"]
+|==============================================================================
+| Configuration  | Upper section | Middle Section | Lower section
+| EF=0, E varies | address[XLENMAX-1:E + MW] + ct | T[MW - 1:0] | {E{1'b0}}
+| EF=1, i.e. E=0 | address[XLENMAX:MW] + ct     2+| T[MW - 1:0]
+|==============================================================================
+
+The _representable range_ defines the range of addresses which do not corrupt
+the bounds encoding. The encoding was first introduced in
+xref:section_cap_encoding[xrefstyle=short], and is repeated in a different
+form in xref:comp_addr_bounds[xrefstyle=short] to aid this description.
+
+For the address to be valid for the current bounds encoding, the address
+bits in the _Upper Section_ of xref:comp_addr_bounds[xrefstyle=short] _must
+not change_ as this will change the meaning of the bounds.
+
+This gives a range of `s=2^E+MW^`, which as shown in
+xref:cap_bounds_map[xrefstyle=short].
+
+The gap between the bounds of the representable range is always guaranteed
+to be at least 1/8 of `s`. This is represented by `R = Bc - 1` in
+xref:section_cap_encoding[xrefstyle=short].
+This gives useful guarantees, such that if an executed instruction is in
+<<pcc>> bounds, then it is also guaranteed that the next linear instruction
+is _representable_.
 
 [#section_cap_malformed]
 === Malformed Capability Bounds

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -349,6 +349,12 @@ Decoding the bounds:
 top:    t = { a[XLENMAX - 1:E + MW] + ct, T[MW - 1:0]    , {E{1'b0}} }
 base:   b = { a[XLENMAX - 1:E + MW] + cb, B[MW - 1:0]    , {E{1'b0}} }
 ```
+NOTE: The representable range
+ is defined by the space beneath the bottom address bit (`a[E + MW]`)
+ in the expression above. If the capability address changes causing that address bit
+ to change, then the representable range is violated and so the tag will be cleared
+ by an instruction such as <<CINCOFFSET>>. This is represented by a range
+ of `s=2^E+MW^` in xref:cap_bounds_map[xrefstyle=short].
 
 The corrections c~t~ and c~b~ are calculated as as shown below using the
 definitions in xref:cap_encoding_ct[xrefstyle=short] and

--- a/src/cheri-pte-ext.adoc
+++ b/src/cheri-pte-ext.adoc
@@ -43,8 +43,8 @@ clears the tag bit of the capability written to a virtual page with the CW bit
 clear.
 
 NOTE: The implementation of the CW bit does not force a dependency on the tag
-bit's value of the capability written, so implementations must support this
-feature.
+bit's value of the capability written, so implementations are not required
+to this feature.
 
 The CD bit indicates that a capability with tag set has been written to the
 virtual page since the last time the CD bit was cleared. Implementations are

--- a/src/cheri-pte-ext.adoc
+++ b/src/cheri-pte-ext.adoc
@@ -43,8 +43,8 @@ clears the tag bit of the capability written to a virtual page with the CW bit
 clear.
 
 NOTE: The implementation of the CW bit does not force a dependency on the tag
-bit's value of the capability written, so implementations are not required
-to this feature.
+bit's value of the capability written, so implementations must support the CW
+bit.
 
 The CD bit indicates that a capability with tag set has been written to the
 virtual page since the last time the CD bit was cleared. Implementations are

--- a/src/cheri-pte-ext.adoc
+++ b/src/cheri-pte-ext.adoc
@@ -55,7 +55,7 @@ to manage the CD bit are permitted:
 instruction is executed, the <<pcc>> grants store capability permission, the
 tag bit of the capability being written is set and the address written
 corresponds to a virtual page with the CD bit clear.
-* When a capability store or AMO instruction is execute, the <<pcc>> grants store
+* When a capability store or AMO instruction is executed, the <<pcc>> grants store
 capability permission, the tag bit of the capability being written is set and
 the store address corresponds to a virtual page with the CD bit clear, the
 implementation sets the corresponding bit in the PTE. The PTE update must be

--- a/src/insns/auipcc_32bit.adoc
+++ b/src/insns/auipcc_32bit.adoc
@@ -25,7 +25,7 @@ Form a 32-bit offset from the 20-bit immediate filling the lowest 12 bits with
 zeros. Increment the address of the <<AUIPCC>> instruction's <<pcc>> by the
 32-bit offset, then write the output capability to `cd`. The tag bit of the
 output capability is 0 if the incremented address is outside the <<pcc>>'s
-representable region.
+<<section_cap_representable_check>>.
 
 Legacy Mode Description::
 Form a 32-bit offset from the immediate, filling in the lowest 12 bits with

--- a/src/insns/cincoffset_32bit.adoc
+++ b/src/insns/cincoffset_32bit.adoc
@@ -31,7 +31,7 @@ cleared by <<CMOVE>>.
 Description::
 Increment the address field of the capability `cs1`  and write the result to
 `cd` . The tag bit of the output capability is 0 if `cs1`  did not have its tag
-set to 1, the incremented address is outside `cs1` 's representable region or
+set to 1, the incremented address is outside `cs1` 's <<section_cap_representable_check>> or
 `cs1`  is sealed. +
 For <<CINCOFFSET>>, the address is incremented by the value in
 `rs2` . +

--- a/src/insns/cj_j_16bit.adoc
+++ b/src/insns/cj_j_16bit.adoc
@@ -33,7 +33,9 @@ Set the next PC following the standard `jal` definition.
  *There is no difference in Capability Mode or Legacy Mode execution for this instruction.*
 
 Exceptions::
-CHERI Length Violation
+See <<CJAL>>, <<JAL>>
+
+include::pcrel_debug_warning.adoc[]
 
 Prerequisites for C.CJ::
 {c_cheri_base_ext_names}

--- a/src/insns/cjal_jal_16bit.adoc
+++ b/src/insns/cjal_jal_16bit.adoc
@@ -29,6 +29,11 @@ include::wavedrom/c-cjal-format-ls.adoc[]
 
 include::cjal_jal_common.adoc[]
 
+Exceptions::
+See <<CJAL>>, <<JAL>>
+
+include::pcrel_debug_warning.adoc[]
+
 Prerequisites for C.CJAL::
 {c_cheri_base_ext_names}
 

--- a/src/insns/cjalr_jalr_16bit.adoc
+++ b/src/insns/cjalr_jalr_16bit.adoc
@@ -29,6 +29,11 @@ include::wavedrom/c-cjalr-format-ls.adoc[]
 
 include::cjalr_jalr_common.adoc[]
 
+Exceptions::
+See <<CJALR>>, <<JALR>>
+
+include::pcrel_debug_warning.adoc[]
+
 Prerequisites C.CJALR::
 {c_cheri_base_ext_names}
 

--- a/src/insns/cjr_jr_16bit.adoc
+++ b/src/insns/cjr_jr_16bit.adoc
@@ -1,13 +1,14 @@
 <<<
 //[#insns-cjr_jr-16bit,reftext="Conditional branches (C.CJR, C.JR), 16-bit encodings"]
 
+[#C_JR,reftext="C.JR"]
+==== C.JR
+
+See <<C.CJR>>.
+
 [#C_CJR,reftext="C.CJR"]
 ==== C.CJR
 
-See <<C.JR>>.
-
-[#C_JR,reftext="C.JR"]
-==== C.JR
 
 Synopsis::
 Register based jumps without link, 16-bit encodings
@@ -35,7 +36,7 @@ Set the next PC according to the standard `jalr` definition.
  Check a minimum length instruction is in <<pcc>> bounds at the target PC, take a CHERI Length Violation exception on error.
 
 Exceptions::
- See <<CJALR>>, <<JALR>>
+See <<CJALR>>, <<JALR>>
 
 include::pcrel_debug_warning.adoc[]
 

--- a/src/insns/cmove_cmv_16bit.adoc
+++ b/src/insns/cmove_cmv_16bit.adoc
@@ -27,7 +27,7 @@ Encoding::
 include::wavedrom/c_mv.adoc[]
 
 Capability Mode Description::
-Capability register cd is replaced with the contents of cs1.
+Capability register `cd` is replaced with the contents of `cs2``.
 
 Legacy Mode Description::
 Standard RISC-V C.MV instruction.

--- a/src/insns/cmove_cmv_16bit.adoc
+++ b/src/insns/cmove_cmv_16bit.adoc
@@ -12,22 +12,22 @@ Synopsis::
 Capability move (C.MV, C.CMOVE), 16-bit encoding
 
 Capability Mode Mnemonic::
-c.cmove cd, cs2`
+c.cmove cd, cs2
 
 Capability Mode Expansion::
-cmove cd, cs2`
+cmove cd, cs2
 
 Legacy Mode Mnemonic::
-c.mv rd, rs2`
+c.mv rd, rs2
 
 Legacy Mode Expansion::
-add rd, x0, rs2`
+add rd, x0, rs2
 
 Encoding::
 include::wavedrom/c_mv.adoc[]
 
 Capability Mode Description::
-Capability register `cd` is replaced with the contents of `cs2``.
+Capability register `cd` is replaced with the contents of `cs2`.
 
 Legacy Mode Description::
 Standard RISC-V C.MV instruction.

--- a/src/insns/csetaddr_32bit.adoc
+++ b/src/insns/csetaddr_32bit.adoc
@@ -17,7 +17,7 @@ include::wavedrom/csetaddr.adoc[]
 Description::
 Set the address field of capability `cs1` to `rs2` and write the output
 capability to `cd`. The tag bit of the output capability is 0 if `cs1` did not
-have its tag set to 1, `rs1` is outside the representable range of `cs1`
+have its tag set to 1, `rs1` is outside the <<section_cap_representable_check>> of `cs1`
 or if `cs1` is sealed.
 
 Prerequisites::

--- a/src/insns/load_16bit_fp_dp.adoc
+++ b/src/insns/load_16bit_fp_dp.adoc
@@ -51,11 +51,11 @@ Standard floating point stack pointer relative load instructions, authorised by 
 
 include::load_exceptions.adoc[]
 
-Prerequisites for C.CFLD, C.CFLDSP::
-{c_cheri_base_ext_names}, and D
+Prerequisites for C.CFLD, C.CFLDSP (RV32 only)::
+{c_cheri_base_ext_names}, and Zcd or D
 
 Prerequisites for C.FLD, C.FLDSP::
-{c_cheri_legacy_ext_names}, and D
+{c_cheri_legacy_ext_names}, and Zcd or D
 
 Operation (after expansion to 32-bit encodings)::
  See <<FLD>>

--- a/src/insns/load_16bit_fp_sp.adoc
+++ b/src/insns/load_16bit_fp_sp.adoc
@@ -27,7 +27,7 @@ Standard floating point load instructions, authorised by the capability in <<ddc
 include::load_exceptions.adoc[]
 
 Prerequisites::
-{c_cheri_legacy_ext_names}, and F
+{c_cheri_legacy_ext_names}, and Zcf or F
 
 Operation (after expansion to 32-bit encodings)::
  See <<FLW>>

--- a/src/insns/sh123add_32bit.adoc
+++ b/src/insns/sh123add_32bit.adoc
@@ -43,16 +43,16 @@ Encoding::
     { bits:  5, name: 'rd' },
     { bits:  3, name: 0x2, attr: ['SH1ADD=010', 'CSH1ADD=010', 'SH2ADD=100', 'CSH2ADD=100', 'SH3ADD=110', 'CSH3ADD=110'] },
     { bits:  5, name: 'rs1' },
-    { bits:  5, name: 'rs2' },
+    { bits:  5, name: 'cs2/rs2' },
     { bits:  7, name: 0x10, attr: ['SH[1|2|3]ADD', 'CSH[1|2|3]ADD'] },
 ]}
 ....
 
 Capability Mode Description::
-Increment the address field of `cs1` by `rs2` shifted left by _n_ bit positions. Clear the tag if the resulting capability is unrepresentable or `cs1` is sealed.
+Increment the address field of `cs2` by `rs1` shifted left by _n_ bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
 
 Legacy Mode Description::
-Increment the address field of `rs1` by `rs2` shifted left by _n_ bit positions.
+Increment `rs2` by `rs1` shifted left by _n_ bit positions.
 
 Prerequisites CSH[1|2|3]ADD::
 {cheri_base_ext_name}, Zba

--- a/src/insns/sh123adduw_32bit.adoc
+++ b/src/insns/sh123adduw_32bit.adoc
@@ -43,16 +43,16 @@ Encoding::
     { bits:  5, name: 'rd' },
     { bits:  3, name: 0x2, attr: ['rv64: SH1ADD.UW=010', 'rv64: CSH1ADD.UW=010', 'rv64: SH2ADD.UW=100', 'rv64: CSH2ADD.UW=100', 'rv64: SH3ADD.UW=110', 'rv64: CSH3ADD.UW=110'] },
     { bits:  5, name: 'rs1' },
-    { bits:  5, name: 'rs2' },
+    { bits:  5, name: 'cs2/rs2' },
     { bits:  7, name: 0x10, attr: ['rv64: SH[1|2|3]ADD.UW', 'rv64: CSH[1|2|3]ADD.UW'] },
 ]}
 ....
 
 Capability Mode Description::
-Increment the address field of `cs1` by the unsigned word in `rs2` shifted left by _n_ bit positions. Clear the tag if the resulting capability is unrepresentable or `cs1` is sealed.
+Increment the address field of `cs2` by the unsigned word in `rs1` shifted left by _n_ bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
 
 Legacy Mode Description::
-Increment the address field of `rs1` by the unsigned word in `rs2` shifted left by _n_ bit positions.
+Increment `rs2` by the unsigned word in `rs1` shifted left by _n_ bit positions.
 
 Prerequisites CSH[1|2|3]ADD.UW::
 {cheri_base_ext_name}, Zba

--- a/src/insns/sh4add_32bit.adoc
+++ b/src/insns/sh4add_32bit.adoc
@@ -30,16 +30,16 @@ Encoding::
     { bits:  5, name: 'rd' },
     { bits:  3, name: 0x7, attr: ['CSH4ADD','SH4ADD'] },
     { bits:  5, name: 'rs1' },
-    { bits:  5, name: 'rs2' },
+    { bits:  5, name: 'cs2/rs2' },
     { bits:  7, name: 16, attr: ['CSH4ADD','SH4ADD'] },
 ]}
 ....
 
 Capability Mode Description::
-Increment the address field of `cs1` by `rs2` shifted left by 4 bit positions. Clear the tag if the resulting capability is unrepresentable or `cs1` is sealed.
+Increment the address field of `cs2` by `rs1` shifted left by 4 bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
 
 Legacy Mode Description::
-Increment the address field of `rs1` by `rs2` shifted left by 4 bit positions.
+Increment `rs2` by `rs1` shifted left by 4 bit positions.
 
 Prerequisites CSH4ADD::
 {cheri_base_ext_name}

--- a/src/insns/sh4adduw_32bit.adoc
+++ b/src/insns/sh4adduw_32bit.adoc
@@ -26,16 +26,16 @@ Encoding::
     { bits:  5, name: 'rd' },
     { bits:  3, name: 0x7, attr: ['CSH4ADD.UW', 'SH4ADD.UW'] },
     { bits:  5, name: 'rs1' },
-    { bits:  5, name: 'rs2' },
+    { bits:  5, name: 'cs2/rs2' },
     { bits:  7, name: 16, attr: ['CSH4ADD.UW', 'SH4ADD.UW'] },
 ]}
 ....
 
 Capability Mode Description::
-Increment the address field of `cs1` by the unsigned word in `rs2` shifted left by 4 bit positions. Clear the tag if the resulting capability is unrepresentable or `cs1` is sealed.
+Increment the address field of `cs2` by the unsigned word in `rs1` shifted left by 4 bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
 
 Legacy Mode Description::
-Increment the address field of `rs1` by the unsigned word in `rs2` shifted left by 4 bit positions.
+Increment `rs2` by the unsigned word in `rs1` shifted left by 4 bit positions.
 
 Prerequisites CSH4ADD::
 {cheri_base_ext_name}

--- a/src/insns/store_16bit_fp_dp.adoc
+++ b/src/insns/store_16bit_fp_dp.adoc
@@ -51,11 +51,11 @@ Standard floating point stack pointer relative store instructions, authorised by
 
 include::store_exceptions.adoc[]
 
-Prerequisites for C.CFSD, C.CFSDSP::
-{c_cheri_base_ext_names}
+Prerequisites for C.CFSD, C.CFSDSP (RV32 only)::
+{c_cheri_base_ext_names}, and Zcd or D
 
 Prerequisites for C.FSD, C.FSDSP::
-{c_cheri_legacy_ext_names}
+{c_cheri_legacy_ext_names}, and Zcd or D
 
 Operation (after expansion to 32-bit encodings)::
  See <<CFSD>>, <<FSD>>

--- a/src/insns/store_16bit_fp_sp.adoc
+++ b/src/insns/store_16bit_fp_sp.adoc
@@ -30,7 +30,7 @@ NOTE: these instructions are not available in Capability Mode, as they have been
 include::store_exceptions.adoc[]
 
 Prerequisites for C.FSW, C.FSWSP::
-{c_cheri_legacy_ext_names}
+{c_cheri_legacy_ext_names}, Zcf or F
 
 Operation (after expansion to 32-bit encodings)::
  See <<FSW>>

--- a/src/insns/wavedrom/c-cjalr-format-ls.adoc
+++ b/src/insns/wavedrom/c-cjalr-format-ls.adoc
@@ -4,8 +4,8 @@
 ....
 {reg: [
   {bits: 2, name: 'op',      type: 8, attr: ['2','C2=10']},
-  {bits: 5, name: 'rs2',     type: 4, attr: ['5','0']},
-  {bits: 5, name: 'rs1',     type: 4, attr: ['5','src!=0']},
+  {bits: 5, name: 'cs2/rs2',     type: 4, attr: ['5','0']},
+  {bits: 5, name: 'cs1/rs1',     type: 4, attr: ['5','src!=0']},
   {bits: 4, name: 'funct4',  type: 8, attr: ['4', 'cap: C.CJALR=1001', 'leg: C.JALR=1001']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-cr-format-ls.adoc
+++ b/src/insns/wavedrom/c-cr-format-ls.adoc
@@ -4,8 +4,8 @@
 ....
 {reg: [
   {bits: 2, name: 'op',      type: 8, attr: ['2','C2=10']},
-  {bits: 5, name: 'rs2',     type: 4, attr: ['5','0']},
-  {bits: 5, name: 'rs1',     type: 4, attr: ['5','src!=0']},
+  {bits: 5, name: 'cs2/rs2',     type: 4, attr: ['5','0']},
+  {bits: 5, name: 'cs1/rs1',     type: 4, attr: ['5','src!=0']},
   {bits: 4, name: 'funct4',  type: 8, attr: ['4','cap: C.CJR=1000', 'leg: C.JR=1000']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/csetmode.adoc
+++ b/src/insns/wavedrom/csetmode.adoc
@@ -6,7 +6,7 @@
   {bits: 5,  name: 'cd',      attr: ['5', 'dest'], type: 2},
   {bits: 3,  name: 'funct3',  attr: ['3', 'CSETMODE=000'], type: 8},
   {bits: 5,  name: 'cs1',     attr: ['5', 'src1'], type: 4},
-  {bits: 5,  name: 'rs2',     attr: ['5', 'CSETMODE=0011'], type: 3},
+  {bits: 5,  name: 'rs2',     attr: ['5', 'mode'], type: 3},
   {bits: 7,  name: 'funct7',  attr: ['7', 'CSETMODE=0001000'], type: 3},
 ]}
 ....

--- a/src/insns/wavedrom/csetmode.adoc
+++ b/src/insns/wavedrom/csetmode.adoc
@@ -4,9 +4,9 @@
 {reg: [
   {bits: 7,  name: 'opcode',  attr: ['7', 'OP=0110011'], type: 8},
   {bits: 5,  name: 'cd',      attr: ['5', 'dest'], type: 2},
-  {bits: 3,  name: 'funct3',  attr: ['3', 'CSETMODE=000'], type: 8},
+  {bits: 3,  name: 'funct3',  attr: ['7', 'CSETMODE=111'], type: 8},
   {bits: 5,  name: 'cs1',     attr: ['5', 'src1'], type: 4},
-  {bits: 5,  name: 'rs2',     attr: ['5', 'mode'], type: 3},
-  {bits: 7,  name: 'funct7',  attr: ['7', 'CSETMODE=0001000'], type: 3},
+  {bits: 5,  name: 'rs2',     attr: ['5', 'src2'], type: 3},
+  {bits: 7,  name: 'funct7',  attr: ['7', 'CSETMODE=0000110'], type: 3},
 ]}
 ....

--- a/src/insns/zcmp_cmpopretz.adoc
+++ b/src/insns/zcmp_cmpopretz.adoc
@@ -9,7 +9,7 @@ See <<CM.CPOPRETZ>> and cite:[riscv-code-size-spec].
 ==== CM.CPOPRETZ
 
 Synopsis::
-Destroy stack frame (CM.CPOPRETZ, CM.POPRETZ): load the return address register and 0 to 12 saved registers from the stack frame, deallocate the stack frame. Move zero into argument register zero. Return through the return address register. 16-bit encodings.
+Destroy stack frame (CM.CPOPRETZ, CM.POPRETZ): load the return address register and register 0 to 12 saved registers from the stack frame, deallocate the stack frame. Move zero into argument register zero. Return through the return address register. 16-bit encodings.
 
 Capability Mode Mnemonic::
 `cm.cpopretz \{creg_list\}, -stack_adj`

--- a/src/instructions.adoc
+++ b/src/instructions.adoc
@@ -17,7 +17,7 @@ jumps and conditional branches is bounds checked against <<pcc>> regardless of
 CHERI execution mode
 
 NOTE: Not all RISC-V extensions have been checked against CHERI. Compatible
-extensions, will eventually be listed in a CHERI profile.
+extensions will eventually be listed in a CHERI profile.
 
 <<<
 === "Zcheri_purecap", "Zcheri_legacy" and "Zcheri_mode" Extensions for CHERI

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -576,7 +576,7 @@ encountered an exception. Otherwise, <<mepcc>> is never written by the
 implementation, though it may be explicitly written by software.
 
 As shown in xref:CSR_exevectors[xrefstyle=short], <<mepcc>> is an executable
-vector, so it need not be able to hold all possible invalid addresses.
+vector, so it does not need to be able to hold all possible invalid addresses.
 Additionally the capability in <<mepcc>> is unsealed when it is installed in
 <<pcc>> on execution of an <<MRET>> instruction.
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -32,11 +32,12 @@ where address 2^XLENMAX^ - 1 is within the bounds.
 === Programmer's Model for Zcheri_purecap
 
 For {cheri_base_ext_name}, the 32 unprivileged *x* registers of the base
-integer ISA are extended so that they are able to hold a capability as well as renamed to *c* registers. Therefore,
-each *c* register is CLEN bits wide and has an out of band tag bit. The *x*
-notation refers to the address field of the capability in an unprivileged
-register while the *c* notation is used to refer to the full capability (i.e.
-address, metadata and tag) held in the same unprivileged register.
+integer ISA are extended so that they are able to hold a capability as well
+as renamed to *c* registers. Therefore, each *c* register is CLEN bits wide
+and has an out of band tag bit. The *x* notation refers to the address field
+of the capability in an unprivileged register while the *c* notation is used
+to refer to the full capability (i.e. address, metadata and tag) held in the
+same unprivileged register.
 
 Register *c0* is hardwired with all bits, including the capability metadata and
 tag, equal to 0. In other words, *c0* is hardwired to the <<null-cap>>

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1013,6 +1013,8 @@ Unlike machine and supervisor level CSRs, {cheri_base_ext_name} does not require
 The <<pcc>> is made visible in a CSR. This provides access to an
 <<infinite-cap>> capability while in debug mode without executing <<AUIPCC>>.
 
+<<pcc>> resets to the <<infinite-cap>> with the address field set to the core boot address.
+
 NOTE: It is common for implementations to not allow executing *pc* relative
 instructions, such as <<AUIPC>> or <<JAL>>, in debug mode.
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1013,7 +1013,7 @@ Unlike machine and supervisor level CSRs, {cheri_base_ext_name} does not require
 The <<pcc>> is made visible in a CSR. This provides access to an
 <<infinite-cap>> capability while in debug mode without executing <<AUIPCC>>.
 
-<<pcc>> resets to the <<infinite-cap>> with the address field set to the core boot address.
+<<pcc>> resets to the <<infinite-cap>> capability with the address field set to the core boot address.
 
 NOTE: It is common for implementations to not allow executing *pc* relative
 instructions, such as <<AUIPC>> or <<JAL>>, in debug mode.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -32,8 +32,8 @@ where address 2^XLENMAX^ - 1 is within the bounds.
 === Programmer's Model for Zcheri_purecap
 
 For {cheri_base_ext_name}, the 32 unprivileged *x* registers of the base
-integer ISA are extended so that they are able to hold a capability. Therefore,
-each *x* register is CLEN bits wide and has an out of band tag bit. The *x*
+integer ISA are extended so that they are able to hold a capability as well as renamed to *c* registers. Therefore,
+each *c* register is CLEN bits wide and has an out of band tag bit. The *x*
 notation refers to the address field of the capability in an unprivileged
 register while the *c* notation is used to refer to the full capability (i.e.
 address, metadata and tag) held in the same unprivileged register.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -24,8 +24,8 @@ data they protect.
 
 The memory address space is circular, so the byte at address
 2^XLEN^ - 1 is adjacent to the byte at address zero. A capability's
-representable region described in xref:section_cap_encoding[xrefstyle=short] is
-also circular, so address 0 is within the representable region of a capability
+<<section_cap_representable_check>> described in xref:section_cap_encoding[xrefstyle=short] is
+also circular, so address 0 is within the <<section_cap_representable_check>> of a capability
 where address 2^XLENMAX^ - 1 is within the bounds.
 
 [#section_riscv_programmers_model]
@@ -207,7 +207,7 @@ build <<pcc>>-relative capabilities. <<AUIPCC>> forms a 32-bit offset from the 2
 immediate and filling the lowest 12 bits with zeros. The <<pcc>> address is then
 incremented by the offset and a representability check is performed so the
 capability's tag is cleared if the new address is outside the <<pcc>>'s
-representable region. The resulting CLEN value along with the new tag are
+<<section_cap_representable_check>>. The resulting CLEN value along with the new tag are
 written to a *c* register.
 
 ==== Control Transfer Instructions
@@ -298,7 +298,7 @@ xref:csr-numbers-section[xrefstyle=short].
 
 Reading or writing any part of a CLEN-bit CSR may cause
 side-effects. For example, the CSR's tag bit may be cleared if a new address
-is outside the representable region of a CSR capability being written.
+is outside the <<section_cap_representable_check>> of a CSR capability being written.
 
 This section describes how the CSR instructions operate on these CSRs in
 {cheri_base_ext_name}.
@@ -564,7 +564,7 @@ Capabilities written to <<mepcc>> must be legalised by implicitly zeroing bit
 either 16 or 32, then whenever IALIGN=32, the capability read from <<mepcc>>
 must be legalised by implicitly zeroing bit **mepcc[1]**. Therefore, the
 capability read or written has its tag bit cleared if the legalised address is
-not within the representable region.
+not within the <<section_cap_representable_check>>.
 
 NOTE: When reading or writing a sealed capability in <<mepcc>>, the
 tag is not cleared if the original address equals the legalized

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -117,7 +117,7 @@ output tag is always 0
 * <<CANDPERM>>: bitwise AND of a mask value with a bit map representation of the
 architectural (AP) and software-defined (SDP) permissions fields
 * <<CSETBOUNDS>>: set the base and length of a capability. The tag is
-cleared, if the encoding cannot represents the bounds exactly
+cleared, if the encoding cannot represent the bounds exactly
 * <<CSETBOUNDSINEXACT>>: set the base and length of a capability. The base will be
 rounded down and/or the length will be rounded up if the encoding cannot represent
 the bounds exactly
@@ -177,7 +177,7 @@ The indirect jump and link <<pcc>> (<<JALR_PCC>>) instruction allows uncondition
 jumps to a target address. The target address is provided in an *x* register;
 the new address is installed in the address field of the <<pcc>>. The address of
 the instruction following the jump (*pc* + 4) is written to an *x* register.
-<<JALR_PCC>> causes an exceptions when a minimum sized instruction at the
+<<JALR_PCC>> causes an exception when a minimum sized instruction at the
 target address is not within the bounds of the <<pcc>> or the target address is
 misaligned.
 
@@ -1057,7 +1057,7 @@ NOTE: `auth_cap` is <<ddc>> for Legacy mode and `cs1` for Capability Mode
 | all stores, all atomics, all cbos | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_seal}   |`auth_cap` seal       | isCapSealed(`auth_cap`)
 |             all atomics, all cbos | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_perm}   |`auth_cap` permission | AMO only: not(`auth_cap`.<<r_perm>>)
 | all stores, all atomics, all cbos | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_perm}   |`auth_cap` permission | not(auto_cap.<<w_perm>>)
-| all stores, all atomics           | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_length} |`auth_cap` length     | any byte of access^!^ out of `auth_cap` bounds
+| all stores, all atomics           | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_length} |`auth_cap` length     | any byte of access^1^ out of `auth_cap` bounds
 | capability stores, all atomics    |6                     | N/A                     | N/A                        |Misaligned store/AMO| Misaligned capability store or AMO
 |=========================================================================================
 
@@ -1112,7 +1112,7 @@ invalid addresses. Prior to writing these CSRs, implementations may convert an
 invalid address into some other invalid address that the register is capable of
 holding. However, these registers hold capabilities in {cheri_base_ext_name}
 and the bounds encoding depends on the address value, so implementations must
-not convert invalid addresses to other arbitrary invalid address in an
+not convert invalid addresses to other arbitrary invalid addresses in an
 unrestricted manner.
 The following procedure must be used instead when writing a capability A to
 these CSRs:

--- a/src/riscv-legacy-integration.adoc
+++ b/src/riscv-legacy-integration.adoc
@@ -142,7 +142,7 @@ address of the instruction following the jump (*pc* + 4) is written to an *x*
 register; that register's tag and capability metadata are zeroed.
 
 <<JAL>> and <<JALR>> cause CHERI exceptions when a minimum sized instruction
-at the target address are not within the bounds of the <<pcc>>. An
+at the target address is not within the bounds of the <<pcc>>. An
 instruction address misaligned exception is raised when the target address is
 misaligned.
 

--- a/src/riscv-legacy-integration.adoc
+++ b/src/riscv-legacy-integration.adoc
@@ -189,8 +189,9 @@ When the XLEN-bit alias is used by <<CSRRW>>:
 * Only XLEN bits from the *x* source are written to the capability address
 field.
     ** The tag and metadata are updated as specified in <<extended_CSR_writing>>.
-* Only XLEN bits are read from the capability address field, which is zero
-extended to the destination *x* register.
+* Only XLEN bits are read from the capability address field, which are extended
+to XLENMAX bits according to cite:[riscv-unpriv-spec] and are then written
+to the destination *x* register.
 
 When the CLEN-bit alias is used by <<CSRRW>>:
 

--- a/src/riscv-mode-integration.adoc
+++ b/src/riscv-mode-integration.adoc
@@ -32,6 +32,8 @@ include::img/cap-encoding-xlen64-mode.edn[]
 not grant <<x_perm>>. In this case, the M bit is superfluous, so the encoding
 may be used to support additional features in future extensions.
 
+The M bit is 0 in both the <<null-cap>> and <<infinite-cap>> capabilities.
+
 [#section_mode_cap_instructions]
 === Zcheri_mode Instructions
 

--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -99,6 +99,8 @@ include::generated/csr_alias_action_table_body.adoc[]
  in within bounds of the capability written to `Xtvecc`. The check on writing
  must include the lowest (0 offset) and highest possible offset (e.g. 64 * XLENMAX bits where HICAUSE=16).
 
+NOTE: _XLEN writing_ is only available if {cheri_mode_ext_name} is implemented.
+
 NOTE: Implementations which allow misa.C to be writable need to legalise *Xepcc*
  on _reading_ if the misa.C value has changed since the value was written as this
  can cause the read value of bit [1] to change state.


### PR DESCRIPTION
- Fix minor nits
- Fix confusing wording about CW
- Fixed unclear formulation about x and c registers
- Corrected register name for c.mv instruction
- fixed backticks in c.mv
- Added word to make clear that this refers to register 0
- honour the text wrapping
- Specify value of mode bit in null/infinite caps
- Deploy to Github pages on release
- improve wording
- minor clarifications
- Fix misunderstanding CW mandatory implementation
- Added exceptions to compressed jump instructions
- Fixed encoding for c.cjalr and c.cjr
- [RISCV-CHERI] Fix description of CSetMode
- overhaul representable region description
- move encoding to allow rs2, and match risc-v opcodes
- correct shift and add operands
- correct prerequisite rules
- fix comments
- remove incorrect text about zero extension
